### PR TITLE
fix: mysql client test

### DIFF
--- a/php-structure-test.yaml
+++ b/php-structure-test.yaml
@@ -85,10 +85,15 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["git version"]
 
-  - name: "MySQL client is installed"
-    command: "mysql"
+  # - name: "MySQL client is installed"
+  #   command: "bash"
+  #   args: ["-c", "mysql --version 2>/dev/null"]
+  #   expectedOutput: ["mysql from", "client"]
+
+  - name: "MariaDB client is installed"
+    command: "mariadb"
     args: ["--version"]
-    expectedOutput: ["mysql  Ver"]
+    expectedOutput: ["mariadb"]
 
   - name: "Unzip is installed"
     command: "unzip"


### PR DESCRIPTION
The `php-structure-test.yaml` file currently uses the `mysql --version` command to test the client. However, MySQL has deprecated this command for version verification and recommends using the `mariadb --version` command instead.

This PR updates the test command to use mariadb in place of mysql to align with the recommendation.

MySQL Error:
```
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
```