### PR TITLE
fix(ols): Fix OLS permission issue caused by binding to uid 1000

### DIFF
--- a/openlitespeed/Dockerfile
+++ b/openlitespeed/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETPLATFORM
 # Install necessary packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget curl cron less tzdata gnupg2 ca-certificates procps libatomic1 \
-    msmtp git \
+    msmtp git mysql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and install OpenLiteSpeed
@@ -48,8 +48,8 @@ RUN wget -qO /usr/local/bin/composer https://getcomposer.org/download/latest-sta
     && chmod +x /usr/local/bin/wp \
     && echo "alias wp='wp --allow-root'" >> /root/.bashrc
 
-# Set up www-data user
-RUN usermod -u 1000 www-data
+# Clearing Group ID 1000 for later use
+RUN groupmod -g 999 lsadm
 
 # Create necessary directories
 RUN mkdir -p /var/www/html/public /var/www/html/logs \
@@ -78,6 +78,13 @@ RUN chown -R lsadm:lsadm /usr/local/lsws \
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# TEmp
+RUN chown -R lsadm:lsadm /usr/local/lsws
+RUN chmod 777 /usr/local/lsws/bin/
+RUN chown -R www-data:www-data /usr/local/lsws/conf/
+
+
 EXPOSE 80
+#USER www-data
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/openlitespeed/build.sh
+++ b/openlitespeed/build.sh
@@ -3,7 +3,7 @@
 # Set variables
 DOCKER_HUB_USERNAME="meghsh"
 IMAGE_NAME="openlitespeed"
-OLS_VERSION="1.8.1"
+OLS_VERSION="1.8.3"
 
 # Ensure BuildKit is enabled
 export DOCKER_BUILDKIT=1

--- a/openlitespeed/entrypoint.sh
+++ b/openlitespeed/entrypoint.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 set -e
 
+echo "www-data UID is: $(id -u www-data) and GID $(id -g www-data)"
+
+
+# Check and set PGID and PUID
+if [ -z "$PGID" ] || [ -z "$PUID" ]; then
+    echo "PGID or PUID not set, using defaults."
+    PGID=1000
+    PUID=1000
+fi
+echo "setting UID to $PGID and GUID $PUID"
+
+groupmod -g $PGID www-data
+usermod -u $PUID www-data
+
+# echo "www-data group ID is: $(id -u www-data) and $(id -g www-data)"
+# echo "$(whoami) group ID is: $(id -u) and $(id -g)"
+
 # Ensure correct permissions
 chown -R www-data:www-data /var/www/html
 chown -R lsadm:lsadm /usr/local/lsws
-find /var/www/html -type d -exec chmod 755 {} \;
-find /var/www/html -type f -exec chmod 644 {} \;
+# find /var/www/html -type d -exec chmod 755 {} \;
+# find /var/www/html -type f -exec chmod 644 {} \;
+
 
 # Start OpenLiteSpeed
 echo "Starting OpenLiteSpeed..."


### PR DESCRIPTION
Fixes [#49](https://github.com/flywp/issues/issues/49)


### Proposed changes

- Add support for two environment variables, PUID and PGID, that allows FlyWP to override the user and group IDs used inside the container.

- set these variables in docker-compose.yml, if no variables exist, use the default 1000

- Update /entrypoint.sh to read PUID and PGID (defaulting to 1000 when they are not provided) and run chown so that file permissions match the requested UID / GID before the main process starts.


With this change, the container no longer assumes that the default fly user has UID 1000, making it compatible with hosts that map container users to different IDs.