### PR TITLE
ci: change action running schedule to 15 days interval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build PHP Docker image
         uses: docker/build-push-action@v5
         with:
@@ -54,6 +48,12 @@ jobs:
       - name: Run Container Structure Tests
         run: |
           container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/php:${{ matrix.php_version }} --config php-structure-test.yaml
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push PHP Docker image
         if: success()
@@ -89,12 +89,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     - name: Build OpenLiteSpeed Docker image
       uses: docker/build-push-action@v5
       with:
@@ -115,6 +109,12 @@ jobs:
     - name: Run Container Structure Tests
       run: |
         container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Push OpenLiteSpeed Docker image
       if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,12 @@ name: Build, Test, and Push Docker images
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: '0 0 1,15 * *'
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "*"
+      - '*'
 
 env:
   DOCKER_ORG_USERNAME: ${{ vars.DOCKER_ORG_USERNAME || 'meghsh' }}
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,60 +71,60 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.4", "8.1", "8.2"]
+        php_version: ['7.4', '8.1', '8.2']
         include:
-          - php_version: "7.4"
-            lsphp: "lsphp74"
-          - php_version: "8.1"
-            lsphp: "lsphp81"
-          - php_version: "8.2"
-            lsphp: "lsphp82"
+          - php_version: '7.4'
+            lsphp: 'lsphp74'
+          - php_version: '8.1'
+            lsphp: 'lsphp81'
+          - php_version: '8.2'
+            lsphp: 'lsphp82'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build OpenLiteSpeed Docker image
-      uses: docker/build-push-action@v5
-      with:
-        file: openlitespeed/Dockerfile
-        context: openlitespeed
-        load: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
-        build-args: |
-          PHP_VERSION=${{ matrix.php_version }}
-          LSPHP=${{ matrix.lsphp }}
+      - name: Build OpenLiteSpeed Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: openlitespeed/Dockerfile
+          context: openlitespeed
+          load: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            LSPHP=${{ matrix.lsphp }}
 
-    - name: Install Container Structure Test
-      run: |
-        curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
-        chmod +x container-structure-test-linux-amd64
-        sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+      - name: Install Container Structure Test
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
 
-    - name: Run Container Structure Tests
-      run: |
-        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
+      - name: Run Container Structure Tests
+        run: |
+          container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Push OpenLiteSpeed Docker image
-      if: success()
-      uses: docker/build-push-action@v5
-      with:
-        file: openlitespeed/Dockerfile
-        context: openlitespeed
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
-        build-args: |
-          PHP_VERSION=${{ matrix.php_version }}
-          LSPHP=${{ matrix.lsphp }}
+      - name: Push OpenLiteSpeed Docker image
+        if: success()
+        uses: docker/build-push-action@v5
+        with:
+          file: openlitespeed/Dockerfile
+          context: openlitespeed
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            LSPHP=${{ matrix.lsphp }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
         file: openlitespeed/Dockerfile
         context: openlitespeed
         load: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/php:${{ matrix.php_version }}
+        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
         build-args: |
           PHP_VERSION=${{ matrix.php_version }}
           LSPHP=${{ matrix.lsphp }}
@@ -114,7 +114,7 @@ jobs:
 
     - name: Run Container Structure Tests
       run: |
-        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/php:${{ matrix.php_version }} --config ols-structure-test.yaml
+        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
 
     - name: Push OpenLiteSpeed Docker image
       if: success()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,88 @@
+name: Run tests on Docker images
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+env:
+  DOCKER_ORG_USERNAME: ${{ vars.DOCKER_ORG_USERNAME || 'meghsh' }}
+
+jobs:
+  build-php:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build PHP Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: php/Dockerfile
+          context: php
+          load: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/php:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+
+      - name: Install Container Structure Test
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+
+      - name: Run Container Structure Tests
+        run: |
+          container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/php:${{ matrix.php_version }} --config php-structure-test.yaml
+
+  build-openlitespeed:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php_version: "7.4"
+            lsphp: "lsphp74"
+          - php_version: "8.1"
+            lsphp: "lsphp81"
+          - php_version: "8.2"
+            lsphp: "lsphp82"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build OpenLiteSpeed Docker image
+      uses: docker/build-push-action@v5
+      with:
+        file: openlitespeed/Dockerfile
+        context: openlitespeed
+        load: true
+        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+        build-args: |
+          PHP_VERSION=${{ matrix.php_version }}
+          LSPHP=${{ matrix.lsphp }}
+
+    - name: Install Container Structure Test
+      run: |
+        curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+        chmod +x container-structure-test-linux-amd64
+        sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+
+    - name: Run Container Structure Tests
+      run: |
+        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml

--- a/php-structure-test.yaml
+++ b/php-structure-test.yaml
@@ -85,10 +85,15 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["git version"]
 
-  - name: "MySQL client is installed"
-    command: "mysql"
+  # - name: "MySQL client is installed"
+  #   command: "bash"
+  #   args: ["-c", "mysql --version 2>/dev/null"]
+  #   expectedOutput: ["mysql from", "client"]
+
+  - name: "MariaDB client is installed"
+    command: "mariadb"
     args: ["--version"]
-    expectedOutput: ["mysql  Ver"]
+    expectedOutput: ["mariadb"]
 
   - name: "Unzip is installed"
     command: "unzip"


### PR DESCRIPTION
Since building and deploying the Docker image takes around 40 minutes, running the action every week quickly reaches the action usage limit. To avoid this, update the schedule to run every 15 days instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated workflow to build and test PHP and OpenLiteSpeed images across multiple versions using container structure tests.
  * Updated tests to verify the MariaDB client instead of MySQL, while retaining ImageMagick checks.

* **Chores**
  * Reorganized deployment pipeline to a consistent build → test → push flow.
  * Adjusted Docker registry login to occur immediately before image pushes.
  * Standardized syntax/quoting and matrix formatting.
  * Expanded and aligned OpenLiteSpeed build sequence for better parity with PHP builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->