### PR TITLE
ci: change action running schedule to 15 days interval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,12 @@ name: Build, Test, and Push Docker images
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: '0 0 1,15 * *'
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "*"
+      - '*'
 
 env:
   DOCKER_ORG_USERNAME: ${{ vars.DOCKER_ORG_USERNAME || 'meghsh' }}
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,66 +71,66 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.4", "8.1", "8.2", "8.3", "8.4" ]
+        php_version: ['7.4', '8.1', '8.2', '8.3', '8.4']
         include:
-          - php_version: "7.4"
-            lsphp: "lsphp74"
-          - php_version: "8.1"
-            lsphp: "lsphp81"
-          - php_version: "8.2"
-            lsphp: "lsphp82"
-          - php_version: "8.3"
-            lsphp: "lsphp83"
-          - php_version: "8.4"
-            lsphp: "lsphp84"
+          - php_version: '7.4'
+            lsphp: 'lsphp74'
+          - php_version: '8.1'
+            lsphp: 'lsphp81'
+          - php_version: '8.2'
+            lsphp: 'lsphp82'
+          - php_version: '8.3'
+            lsphp: 'lsphp83'
+          - php_version: '8.4'
+            lsphp: 'lsphp84'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build OpenLiteSpeed Docker image
-      uses: docker/build-push-action@v5
-      with:
-        file: openlitespeed/Dockerfile
-        context: openlitespeed
-        load: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
-        build-args: |
-          PHP_VERSION=${{ matrix.php_version }}
-          LSPHP=${{ matrix.lsphp }}
+      - name: Build OpenLiteSpeed Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: openlitespeed/Dockerfile
+          context: openlitespeed
+          load: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            LSPHP=${{ matrix.lsphp }}
 
-    - name: Install Container Structure Test
-      run: |
-        curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
-        chmod +x container-structure-test-linux-amd64
-        sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+      - name: Install Container Structure Test
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
 
-    - name: Run Container Structure Tests
-      run: |
-        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
+      - name: Run Container Structure Tests
+        run: |
+          container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Push OpenLiteSpeed Docker image
-      if: success()
-      uses: docker/build-push-action@v5
-      with:
-        file: openlitespeed/Dockerfile
-        context: openlitespeed
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
-        build-args: |
-          PHP_VERSION=${{ matrix.php_version }}
-          LSPHP=${{ matrix.lsphp }}
+      - name: Push OpenLiteSpeed Docker image
+        if: success()
+        uses: docker/build-push-action@v5
+        with:
+          file: openlitespeed/Dockerfile
+          context: openlitespeed
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            LSPHP=${{ matrix.lsphp }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+        php_version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,43 +52,43 @@ jobs:
     strategy:
       matrix:
         include:
-          - php_version: "7.4"
-            lsphp: "lsphp74"
-          - php_version: "8.1"
-            lsphp: "lsphp81"
-          - php_version: "8.2"
-            lsphp: "lsphp82"
-          - php_version: "8.3"
-            lsphp: "lsphp83"
-          - php_version: "8.4"
-            lsphp: "lsphp84"
+          - php_version: '7.4'
+            lsphp: 'lsphp74'
+          - php_version: '8.1'
+            lsphp: 'lsphp81'
+          - php_version: '8.2'
+            lsphp: 'lsphp82'
+          - php_version: '8.3'
+            lsphp: 'lsphp83'
+          - php_version: '8.4'
+            lsphp: 'lsphp84'
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build OpenLiteSpeed Docker image
-      uses: docker/build-push-action@v5
-      with:
-        file: openlitespeed/Dockerfile
-        context: openlitespeed
-        load: true
-        tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
-        build-args: |
-          PHP_VERSION=${{ matrix.php_version }}
-          LSPHP=${{ matrix.lsphp }}
+      - name: Build OpenLiteSpeed Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: openlitespeed/Dockerfile
+          context: openlitespeed
+          load: true
+          tags: ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            LSPHP=${{ matrix.lsphp }}
 
-    - name: Install Container Structure Test
-      run: |
-        curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
-        chmod +x container-structure-test-linux-amd64
-        sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+      - name: Install Container Structure Test
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
 
-    - name: Run Container Structure Tests
-      run: |
-        container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml
+      - name: Run Container Structure Tests
+        run: |
+          container-structure-test test --image ${{ env.DOCKER_ORG_USERNAME }}/openlitespeed:${{ matrix.php_version }} --config ols-structure-test.yaml


### PR DESCRIPTION
Since building and deploying the Docker image takes around 40 minutes, running the action every week quickly reaches the action usage limit. To avoid this, update the schedule to run every 15 days instead.